### PR TITLE
fix: update `which-key` command

### DIFF
--- a/lua/mikesposito/main/snippets/utils.lua
+++ b/lua/mikesposito/main/snippets/utils.lua
@@ -10,11 +10,8 @@ local Utils = {}
 --- @param key string
 --- @param desc string
 Utils.label = function(key, desc)
-  which_key.register {
-    [key] = {
-      name = desc,
-      _ = 'which_key_ignore',
-    },
+  which_key.add {
+    { key, desc = desc },
   }
 end
 


### PR DESCRIPTION
The syntax for registering a command using `which-key` is changed, and since then a message has been displaying on editor startup, which is annoying 