### PR TITLE
feat: copy github permalinks

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -14,6 +14,7 @@
   "friendly-snippets": { "branch": "main", "commit": "00ba9dd3df89509f95437b8d595553707c46d5ea" },
   "fzf": { "branch": "master", "commit": "e76aa37fd402f994ff194a02e47576fba928e8f4" },
   "fzf.vim": { "branch": "master", "commit": "ec75ffbfd50630bf2b8d444d89487e149bacf7f3" },
+  "gitlinker.nvim": { "branch": "master", "commit": "cc59f732f3d043b626c8702cb725c82e54d35c25" },
   "gitsigns.nvim": { "branch": "main", "commit": "863903631e676b33e8be2acb17512fdc1b80b4fb" },
   "image.nvim": { "branch": "master", "commit": "88e9693e188b8464b1c426aebb4389fd9db2fcbf" },
   "indent-blankline.nvim": { "branch": "master", "commit": "18603eb949eba08300799f64027af11ef922283f" },

--- a/lua/custom/keymaps.lua
+++ b/lua/custom/keymaps.lua
@@ -68,6 +68,7 @@ K.GIT_HUNK_PREVIEW = lead .. 'ghp'
 K.GIT_LINE_BLAME = lead .. 'ghb'
 K.GIT_TOGGLE_BLAME = lead .. 'gtb'
 K.GIT_TOGGLE_SHOW_DELETED = lead .. 'gtd'
+K.GIT_COPY_PERMALINK = lead .. 'gy'
 
 --- GitHub
 K.GITHUB_ = lead .. 'G'

--- a/lua/mikesposito/main/configs/git.lua
+++ b/lua/mikesposito/main/configs/git.lua
@@ -13,4 +13,7 @@ return {
 
   -- GitHub PRs, issues and reviews
   require 'mikesposito.main.configs.plugins.octo',
+
+  -- Git permalinks
+  require 'mikesposito.main.configs.plugins.gitlinker',
 }

--- a/lua/mikesposito/main/configs/plugins/gitlinker.lua
+++ b/lua/mikesposito/main/configs/plugins/gitlinker.lua
@@ -1,0 +1,11 @@
+return {
+  'ruifm/gitlinker.nvim',
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+  },
+  config = function()
+    require('gitlinker').setup {
+      mappings = nil,
+    }
+  end,
+}

--- a/lua/mikesposito/main/settings/keymaps.lua
+++ b/lua/mikesposito/main/settings/keymaps.lua
@@ -89,6 +89,12 @@ n(K.GIT_HUNK_PREVIEW, gitsigns.preview_hunk, { desc = 'preview git hunk' })
 n(K.GIT_LINE_BLAME, gitsigns.blame_line, { desc = 'git blame line' })
 n(K.GIT_TOGGLE_BLAME, gitsigns.toggle_current_line_blame, { desc = 'toggle git blame line' })
 n(K.GIT_TOGGLE_SHOW_DELETED, gitsigns.toggle_deleted, { desc = 'toggle git show deleted' })
+n(K.GIT_COPY_PERMALINK, function()
+  git.copy_permalink 'n'
+end, { desc = '[Y]ank permalink' })
+v(K.GIT_COPY_PERMALINK, function()
+  git.copy_permalink 'v'
+end, { desc = '[Y]ank permalink' })
 
 -- GitHub keymaps
 label(K.GITHUB_, '[G]ithub')

--- a/lua/mikesposito/main/snippets/git.lua
+++ b/lua/mikesposito/main/snippets/git.lua
@@ -22,4 +22,8 @@ Git.reset_hunk = function()
   gitsigns.reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
 end
 
+Git.copy_permalink = function(mode)
+  require('gitlinker').get_buf_range_url(mode, { action_callback = require('gitlinker.actions').copy_to_clipboard })
+end
+
 return Git


### PR DESCRIPTION
Use `<leader>gy` to copy github permalinks in normal and visual mode